### PR TITLE
Support Linux build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,19 @@
-CC=clang++
+CC=g++
 CCFLAGS=-std=c++11 -Wall
+LIB=libstinkee.a
 LIBSRC=\
-	stinkee_device.cpp \
-	stinkee_signal.cpp \
-	stinkee_squarewaveutil.cpp
+	stinkee_device.o \
+	stinkee_signal.o \
+	stinkee_squarewaveutil.o
 
-stinkeedemo: libstinkee stinkeedemo.cpp
-	$(CC) -I. -L. -lstinkee -lportaudio stinkeedemo.cpp -o stinkeedemo
+stinkeedemo: $(LIB) stinkeedemo.o
+	$(CC) $(CCFLAGS) -o stinkeedemo -L. stinkeedemo.o -lstinkee -lportaudio
 
-libstinkee: $(LIBSRC)
-	$(CC) -c $(CCFLAGS) -I. $(LIBSRC)
-	ar -rcs libstinkee.a *.o
+$(LIB): $(LIBSRC)
+	ar -rcs $(LIB) $?
+
+%.o: %.cpp
+	$(CC) -c $(CCFLAGS) -I. $<
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Replace clang by gcc in the Makefile to use the pre-installed C++
compiler.  On Mac OS X (Yosemite), executing gcc from the command-line
actually calls clang anyway.  Also fix unresolved symbols by reordering
the link line as gcc seems less forgiving than clang.

This Linux build was tested with Ubuntu 14.04 LTS.  The
'portaudio19-dev' package from the default software repositories contain
the required version of PortAudio (v19_20140130).
